### PR TITLE
50 fix height on mobile

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -3,6 +3,7 @@
   import { isSidebarOpen } from '$lib/stores/general'
   import { Bars3Icon, XMarkIcon } from '@babeard/svelte-heroicons/outline'
   import { TransitionChild, TransitionRoot } from '@rgossiaux/svelte-headlessui'
+  import { onMount } from 'svelte'
   import Gravatar from './Gravatar.svelte'
   import TacoIcon from './icons/TacoIcon.svelte'
 
@@ -13,9 +14,18 @@
   isSidebarOpen.subscribe((value) => {
     sidebarOpen = value
   })
+
+  const viewportHeight = () => {
+    document.documentElement.style.setProperty('--viewport-height', `${window.innerHeight}px`)
+  }
+
+  onMount(() => {
+    window.addEventListener('resize', viewportHeight)
+    viewportHeight()
+  })
 </script>
 
-<div class="flex flex-col justify-between h-screen bg-gray-900">
+<div class="flex flex-col justify-between h-screen max-h-[-webkit-fill-available] bg-gray-900">
   <TransitionRoot show={sidebarOpen}>
     <div class="relative z-50 lg:hidden">
       <TransitionChild

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -14,15 +14,6 @@
   isSidebarOpen.subscribe((value) => {
     sidebarOpen = value
   })
-
-  const viewportHeight = () => {
-    document.documentElement.style.setProperty('--viewport-height', `${window.innerHeight}px`)
-  }
-
-  onMount(() => {
-    window.addEventListener('resize', viewportHeight)
-    viewportHeight()
-  })
 </script>
 
 <div class="flex flex-col justify-between h-screen max-h-[-webkit-fill-available] bg-gray-900">

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ArrowPathIcon, PaperAirplaneIcon } from '@babeard/svelte-heroicons/solid'
-  import { createEventDispatcher, afterUpdate, onMount } from 'svelte'
+  import { afterUpdate, createEventDispatcher, onMount } from 'svelte'
   import autosize from 'svelte-autosize'
 
   let question = ''
@@ -49,6 +49,7 @@
           placeholder="Type your message"
           class="no-border w-full items-center my-auto resize-none m-2 placeholder-white placeholder-opacity-50 bg-primary text-white max-h-96"
           use:autosize
+          on:focus={() => dispatch('focus')}
         />
       </div>
       <button

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -49,7 +49,6 @@
           placeholder="Type your message"
           class="no-border w-full items-center my-auto resize-none m-2 placeholder-white placeholder-opacity-50 bg-primary text-white max-h-96"
           use:autosize
-          on:focus={() => dispatch('focus')}
         />
       </div>
       <button

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -15,12 +15,12 @@
     }
   }
 
-  let textareaRef: HTMLTextAreaElement
+  let textarea: HTMLTextAreaElement
   onMount(() => {
-    textareaRef.focus()
+    textarea.focus()
   })
   afterUpdate(() => {
-    textareaRef.focus()
+    textarea.focus()
   })
 </script>
 
@@ -29,7 +29,7 @@
     <div class="flex w-5/6 max-w-5xl shadow-xl">
       <div class="flex justify-centermin-h-[4rem] w-full bg-primary rounded-l-xl">
         <textarea
-          bind:this={textareaRef}
+          bind:this={textarea}
           rows="1"
           name="message"
           bind:value={question}

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -9,8 +9,10 @@
   const dispatch = createEventDispatcher()
 
   function dispatchMessage() {
-    dispatch('message', { question })
-    question = ''
+    if (question.trim() && !loading) {
+      dispatch('message', { question })
+      question = ''
+    }
   }
 
   let textareaRef: HTMLTextAreaElement
@@ -32,7 +34,7 @@
           name="message"
           bind:value={question}
           on:keydown={(e) => {
-            if (e.key === 'Enter' && !isShiftPressed && question.trim() && !loading) {
+            if (e.key === 'Enter' && !isShiftPressed) {
               dispatchMessage()
               e.preventDefault()
             } else if (e.key === 'Shift') {
@@ -49,7 +51,11 @@
           use:autosize
         />
       </div>
-      <button disabled={loading} class="p-3 pr-14 w-12 rounded-r-xl bg-primary group">
+      <button
+        on:click={dispatchMessage}
+        disabled={loading}
+        class="p-3 pr-14 w-12 rounded-r-xl bg-primary group"
+      >
         {#if !loading}
           <PaperAirplaneIcon
             class="text-white h-8 w-10 opacity-40 group-hover:opacity-95 duration-200"

--- a/src/lib/components/ChatRoom.svelte
+++ b/src/lib/components/ChatRoom.svelte
@@ -89,10 +89,6 @@
     loading = false
     console.error(err)
   }
-
-  function handleChatInputFocus() {
-    console.log('ChatInput focused')
-  }
 </script>
 
 <div class="flex flex-col justify-between items-center h-full w-full">
@@ -120,6 +116,6 @@
   {/if}
 
   <div class="self-end py-3 md:py-6 w-full bg-gray-900">
-    <ChatInput {loading} on:message={handleSubmit} on:focus={handleChatInputFocus} />
+    <ChatInput {loading} on:message={handleSubmit} />
   </div>
 </div>

--- a/src/lib/components/ChatRoom.svelte
+++ b/src/lib/components/ChatRoom.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { goto, invalidateAll } from '$app/navigation'
+  import { page } from '$app/stores'
   import ChatInput from '$lib/components/ChatInput.svelte'
   import ChatMessage from '$lib/components/ChatMessage.svelte'
   import RoleSelector from '$lib/components/RoleSelector.svelte'
   import type { ChatWithRelations } from '$lib/server/entities/chat'
+  import { SSE } from 'sse.js'
   import { onDestroy, onMount } from 'svelte'
   import { flip } from 'svelte/animate'
   import { slide } from 'svelte/transition'
-  import { SSE } from 'sse.js'
 
   export let chat: ChatWithRelations | undefined = undefined
 
@@ -62,9 +63,8 @@
       try {
         if (e.data.includes('[DONE]')) {
           loading = false
-          if (!chat) {
-            const chatJson = JSON.parse(e.data.replace('[DONE]', ''))
-            await goto(`/app/chat/${chatJson.chat.id}`)
+          if (!$page.url.href.endsWith(`/app/chat/${chat?.id}`)) {
+            await goto(`/app/chat/${chat?.id}`)
           }
           await invalidateAll()
           scrollToBottom()

--- a/src/lib/components/ChatRoom.svelte
+++ b/src/lib/components/ChatRoom.svelte
@@ -63,7 +63,7 @@
       try {
         if (e.data.includes('[DONE]')) {
           loading = false
-          if (!$page.url.href.endsWith(`/app/chat/${chat?.id}`)) {
+          if ($page.url.pathname !== `/app/chat/${chat?.id}`) {
             await goto(`/app/chat/${chat?.id}`)
           }
           await invalidateAll()

--- a/src/lib/components/ChatRoom.svelte
+++ b/src/lib/components/ChatRoom.svelte
@@ -89,6 +89,10 @@
     loading = false
     console.error(err)
   }
+
+  function handleChatInputFocus() {
+    console.log('ChatInput focused')
+  }
 </script>
 
 <div class="flex flex-col justify-between items-center h-full w-full">
@@ -116,6 +120,6 @@
   {/if}
 
   <div class="self-end py-3 md:py-6 w-full bg-gray-900">
-    <ChatInput {loading} on:message={handleSubmit} />
+    <ChatInput {loading} on:message={handleSubmit} on:focus={handleChatInputFocus} />
   </div>
 </div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2,6 +2,7 @@
   import ChatLink from '$lib/components/ChatLink.svelte'
   import Gravatar from '$lib/components/Gravatar.svelte'
   import type { UserWithUserTeamsActiveTeamAndChats } from '$lib/server/entities/user'
+  import { isSidebarOpen } from '$lib/stores/general'
   import { PlusIcon } from '@babeard/svelte-heroicons/solid'
   import ChevronRight from '@babeard/svelte-heroicons/solid/ChevronRight'
 
@@ -23,12 +24,11 @@
     {#if user?.activeUserTeam?.chats?.length}
       <a
         href="/app"
-        class="mb-2 px-2 py-4 sm:px-4 lg:px-6 hover:bg-accent hover:bg-opacity-10 bg-opacity-10 rounded-lg border-2 border-white border-opacity-20"
+        class="mb-2 px-2 py-4 sm:px-4 lg:px-6 hover:bg-accent hover:bg-opacity-10 bg-opacity-10 rounded-lg border-2 border-white border-opacity-20 flex items-center gap-x-3"
+        on:click={() => isSidebarOpen.set(false)}
       >
-        <div class="flex items-center gap-x-3">
-          <PlusIcon class="h-6 w-6 text-white flex-none" />
-          <h3 class="flex-auto truncate text-lg font-semibold leading-6 text-white">New Chat</h3>
-        </div>
+        <PlusIcon class="h-6 w-6 text-white flex-none" />
+        <h3 class="flex-auto truncate text-lg font-semibold leading-6 text-white">New Chat</h3>
       </a>
       <ul class="overflow-scroll grow flex flex-col gap-2 pt-4">
         {#each user.activeUserTeam.chats as chat}

--- a/src/lib/server/utils/database.ts
+++ b/src/lib/server/utils/database.ts
@@ -22,5 +22,4 @@ export const isUserOwningChat = async (chatId: number, userId: number) => {
 
 export const escapeUserSecrets = (user: User) => {
   user.password = null
-  user.sessionId = null
 }


### PR DESCRIPTION
This was really crazy stuff. The goal here was to adjust the height of the app to the viewport in two cases where it was being hidden on iOS: when the address bar or the virtual keyboard are on display.

Turns out this is a feature (a bug, but Apple calls it a feature) regarding the vh units. So h-screen does height: 100vh, but those units, in iOS, don't reflect the actual visible viewport but the viewport as if it didn't have the browser bar (WTF). The case with the virtual keyboard is even worse because it adds even more height when open (WTAF), but whatever. I checked the ChatGPT web interface, and they couldn't figure it out either. As no one on the whole internet.

But I managed to solve at least the one regarding the address bar. Thanks to [this hack](https://medium.com/quick-code/100vh-problem-with-ios-safari-92ab23c852a8), first I tried the JS because I couldn't make the CSS work, but adding it to the max-h instead of in the min-h did the trick.

References:
* https://twitter.com/AllThingsSmitty/status/1254151507412496384?ref_src=twsrc%5Etfw
* https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/
* https://medium.com/quick-code/100vh-problem-with-ios-safari-92ab23c852a8

## Other small issues resolved here:

* goto 
* send button click
