### PR TITLE
fix: #176 text in "New team" page

### DIFF
--- a/src/lib/components/InputGroup.svelte
+++ b/src/lib/components/InputGroup.svelte
@@ -11,8 +11,8 @@
   <div>
     <h2 class="text-base font-semibold leading-7 text-white">{header}</h2>
     <p class="mt-1 text-sm leading-6 text-gray-400">
-      {description}
-    </p>
+      {@html description}
+    </p>  
   </div>
 
   <div class="md:col-span-2">

--- a/src/routes/app/settings/teams/new/+page.svelte
+++ b/src/routes/app/settings/teams/new/+page.svelte
@@ -17,7 +17,7 @@
 >
   <InputGroup
     header="Create a new Team"
-    description={`You need an OpenAI API key to create a team. You can get one at <a href="https://platform.openai.com" target="_blank">https://platform.openai.com</a>`}
+    description={`You need an OpenAI API key to create a team. You can get one at <a href="https://platform.openai.com" target="_blank" class="text-blue-500 underline hover:text-blue-700">https://platform.openai.com</a>`}
     {form}
   >
     <Input


### PR DESCRIPTION
I'm on the fence about having the html a tag sent in as part of the description string, and considered making it a separate prop in `InputGroup`. It seems like it's used elsewhere without links in the description though, and I guess this component shouldn't have opinions on where in the description a link could appear, so i opted to add the `@html` directive to description instead. 

Let me know if we could go about it differently :) 
