### PR TITLE
175: add support for gpt-4o

### DIFF
--- a/prisma/migrations/20240829115429_add_team_model/migration.sql
+++ b/prisma/migrations/20240829115429_add_team_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "teamModel" TEXT NOT NULL DEFAULT 'gpt-3.5-turbo';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Team {
   name          String  @unique
   openAiApiKey  String?
   ollamaBaseUrl String?
+  teamModel String  @default("gpt-3.5-turbo")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/lib/components/ChatInput.svelte
+++ b/src/lib/components/ChatInput.svelte
@@ -3,16 +3,16 @@
   import UsersTyping from '$lib/components/UsersTyping.svelte'
   import type { Model } from '$lib/server/api/openai'
   import type { ChatWithRelations } from '$lib/server/entities/chat'
-  import { Models } from '$lib/types/models'
   import { PaperAirplaneIcon, StopIcon } from '@babeard/svelte-heroicons/solid'
   import { createEventDispatcher, onMount, tick } from 'svelte'
   import autosize from 'svelte-autosize'
 
   export let chat: ChatWithRelations | undefined = undefined
   export let models: Model[]
+  export let teamModel: string
   export let loading = false
 
-  let model = chat?.model || Models.gpt3
+  let model = chat?.model || teamModel
   let temperature = Number(chat?.temperature) || 0.6
   export let question = ''
   let isShiftPressed = false
@@ -45,7 +45,7 @@
 
   let oldChat: ChatWithRelations | undefined = undefined
   $: if (chat !== oldChat) {
-    model = chat?.model || Models.gpt3
+    model = chat?.model || teamModel
     temperature = Number(chat?.temperature) || 0.6
     oldChat = chat
   }

--- a/src/lib/components/ChatRoom.svelte
+++ b/src/lib/components/ChatRoom.svelte
@@ -28,6 +28,7 @@
   export let chat: ChatWithRelations | undefined = undefined
   export let models: Model[]
   export let customPersonalities: LlmPersonality[] | null = null
+  export let teamModel: string
 
   let loading = false
   let selectedPersonalityContext: string | null = 'You are a helpful assistant.'
@@ -269,6 +270,7 @@
     {chat}
     {models}
     {loading}
+    {teamModel}
     bind:question
     on:message={handleSubmit}
     on:stop={stopSubmit}

--- a/src/lib/components/ChatSettingsPopover.svelte
+++ b/src/lib/components/ChatSettingsPopover.svelte
@@ -28,7 +28,11 @@
           <SmallCards
             {loading}
             bind:value={model}
-            options={models.map((x) => ({ value: x.id, label: x.label, enabled: x.enabled }))}
+            options={models.map((model) => ({
+              value: model.id,
+              label: model.label,
+              enabled: model.enabled,
+            }))}
             heading="Model"
             groupLabel="Choose a model option"
             class="mb-4"

--- a/src/lib/components/SmallCards.svelte
+++ b/src/lib/components/SmallCards.svelte
@@ -33,8 +33,8 @@
               ? 'cursor-pointer focus:outline-none'
               : 'cursor-not-allowed opacity-25'} {active &&
               'ring-2 ring-indigo-600 ring-offset-2'}, {checked
-              ? 'bg-indigo-600 text-white hover:bg-indigo-500'
-              : 'ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50'} flex items-center justify-center rounded-md py-3 px-3 text-sm font-semibold uppercase flex-1"
+              ? 'bg-indigo-600 text-white hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400'
+              : 'ring-1 ring-inset ring-gray-300 bg-white text-gray-900 hover:bg-gray-50 dark:ring-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700'} flex items-center justify-center rounded-md py-3 px-3 text-sm font-semibold uppercase flex-1"
           >
             <RadioGroupLabel
               class="flex whitespace-nowrap"

--- a/src/lib/components/TeamDefaultModel.svelte
+++ b/src/lib/components/TeamDefaultModel.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { Models } from '$lib/types/models'
+  import SmallCards from '$lib/components/SmallCards.svelte'
+  import type { Model } from '$lib/server/api/openai'
+
+  export let models: Model[]
+  let model = Models.gpt3
+</script>
+
+<div class="px-4 sm:px-6 lg:px-8 max-w-6xl py-10">
+  <div class="sm:flex-auto">
+    <h1 class="text-base font-semibold leading-6 text-white">Default model</h1>
+    <p class="mt-2 text-sm text-gray-300">The model used per default when starting a new chat.</p>
+  </div>
+  <SmallCards
+    loading={false}
+    bind:value={model}
+    options={models.map((x) => ({ value: x.id, label: x.label, enabled: x.enabled }))}
+    heading="Model"
+    groupLabel="Choose a model option"
+    class="mb-4"
+  />
+</div>

--- a/src/lib/components/TeamDefaultModel.svelte
+++ b/src/lib/components/TeamDefaultModel.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { enhance } from '$app/forms'
   import SmallCards from '$lib/components/SmallCards.svelte'
   import type { Model } from '$lib/server/api/openai'
+  import Alert from './Alert.svelte'
 
   export let models: Model[]
   export let model: string
+  export let form: Record<string, string> = {}
 </script>
 
 <div class="px-4 sm:px-6 lg:px-8 max-w-6xl py-10">
@@ -13,7 +16,7 @@
       The model used per default when a member of your team starts a new chat.
     </p>
   </div>
-  <form method="post" action="?/updateTeamModel">
+  <form method="post" action="?/updateTeamModel" use:enhance>
     <SmallCards
       loading={false}
       bind:value={model}
@@ -23,10 +26,16 @@
       class="mb-4"
     />
     <input type="hidden" name="model" value={model} />
-    <button
-      type="submit"
-      class="rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-      >Save</button
-    >
+    <div class="flex gap-4">
+      <button
+        type="submit"
+        class="rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+        >Save</button
+      >
+      <Alert
+        type={(form?.error && 'error') || (form?.success && 'success') || 'warning'}
+        title={form?.error || form?.success}
+      />
+    </div>
   </form>
 </div>

--- a/src/lib/components/TeamDefaultModel.svelte
+++ b/src/lib/components/TeamDefaultModel.svelte
@@ -20,7 +20,11 @@
     <SmallCards
       loading={false}
       bind:value={model}
-      options={models.map((x) => ({ value: x.id, label: x.label, enabled: x.enabled }))}
+      options={models.map((model) => ({
+        value: model.id,
+        label: model.label,
+        enabled: model.enabled,
+      }))}
       heading="Model"
       groupLabel="Choose a model option"
       class="mb-4"

--- a/src/lib/components/TeamDefaultModel.svelte
+++ b/src/lib/components/TeamDefaultModel.svelte
@@ -1,23 +1,32 @@
 <script lang="ts">
-  import { Models } from '$lib/types/models'
   import SmallCards from '$lib/components/SmallCards.svelte'
   import type { Model } from '$lib/server/api/openai'
 
   export let models: Model[]
-  let model = Models.gpt3
+  export let model: string
 </script>
 
 <div class="px-4 sm:px-6 lg:px-8 max-w-6xl py-10">
   <div class="sm:flex-auto">
     <h1 class="text-base font-semibold leading-6 text-white">Default model</h1>
-    <p class="mt-2 text-sm text-gray-300">The model used per default when starting a new chat.</p>
+    <p class="mt-2 text-sm text-gray-300">
+      The model used per default when a member of your team starts a new chat.
+    </p>
   </div>
-  <SmallCards
-    loading={false}
-    bind:value={model}
-    options={models.map((x) => ({ value: x.id, label: x.label, enabled: x.enabled }))}
-    heading="Model"
-    groupLabel="Choose a model option"
-    class="mb-4"
-  />
+  <form method="post" action="?/updateTeamModel">
+    <SmallCards
+      loading={false}
+      bind:value={model}
+      options={models.map((x) => ({ value: x.id, label: x.label, enabled: x.enabled }))}
+      heading="Model"
+      groupLabel="Choose a model option"
+      class="mb-4"
+    />
+    <input type="hidden" name="model" value={model} />
+    <button
+      type="submit"
+      class="rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+      >Save</button
+    >
+  </form>
 </div>

--- a/src/lib/server/api/openai.ts
+++ b/src/lib/server/api/openai.ts
@@ -205,6 +205,15 @@ export const MODELS: Model[] = [
     label: 'GPT-4 Turbo 128K',
     enabled: true,
   },
+  {
+    id: 'gpt-4o',
+    input: 0.03,
+    output: 0.06,
+    maxTokens: 4_096,
+    outputRoom: 500,
+    label: 'GPT-4o',
+    enabled: true,
+  },
 ]
 
 export const getModel = (id?: string): Model | undefined => {

--- a/src/lib/server/entities/team.ts
+++ b/src/lib/server/entities/team.ts
@@ -24,6 +24,15 @@ export const updateTeam = async (
   })
 }
 
+export const updateTeamModel = async (id: number, model: string) => {
+  return prisma.team.update({
+    where: { id },
+    data: {
+      teamModel: model,
+    },
+  })
+}
+
 export const getTeamByName = async (name: string) => {
   return prisma.team.findUnique({
     where: {

--- a/src/routes/app/+page.server.ts
+++ b/src/routes/app/+page.server.ts
@@ -12,6 +12,7 @@ export const load: PageServerLoad = async ({ locals: { currentUser } }) => {
   return {
     llmPersonalities: llmPersonalities.length ? llmPersonalities : null,
     models: getAvailableModels(currentUser.activeUserTeam?.team),
+    teamModel: currentUser.activeUserTeam?.team?.teamModel,
   }
 }
 

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -9,4 +9,5 @@
   customPersonalities={data.llmPersonalities || null}
   models={data.models}
   user={data.user}
+  teamModel={data.teamModel}
 />

--- a/src/routes/app/chats/[chatId]/+page.server.ts
+++ b/src/routes/app/chats/[chatId]/+page.server.ts
@@ -15,6 +15,7 @@ export const load: PageServerLoad = async ({ params, locals: { currentUser } }) 
     return {
       chat: getChatWithRelationsById(chatId),
       models: getAvailableModels(currentUser.activeUserTeam?.team),
+      teamModel: currentUser.activeUserTeam?.team?.teamModel,
     }
   } catch (error) {
     throw redirect(303, '/app')

--- a/src/routes/app/chats/[chatId]/+page.svelte
+++ b/src/routes/app/chats/[chatId]/+page.svelte
@@ -6,4 +6,4 @@
   export let data: PageData
 </script>
 
-<ChatRoom chat={data.chat} models={data.models} user={data.user} />
+<ChatRoom chat={data.chat} models={data.models} teamModel={data.teamModel} user={data.user} />

--- a/src/routes/app/settings/teams/[id]/+page.server.ts
+++ b/src/routes/app/settings/teams/[id]/+page.server.ts
@@ -276,7 +276,7 @@ export const actions: Actions = {
 
     return {
       modelSection: {
-        success: 'Model updated successfully.',
+        success: 'Team model updated successfully.',
       },
     }
   },

--- a/src/routes/app/settings/teams/[id]/+page.server.ts
+++ b/src/routes/app/settings/teams/[id]/+page.server.ts
@@ -5,7 +5,12 @@ import {
   getInvitationById,
   getInvitationsByTeamId,
 } from '$lib/server/entities/invitation'
-import { getTeamByIdWithMembers, getTeamByName, updateTeam } from '$lib/server/entities/team'
+import {
+  getTeamByIdWithMembers,
+  getTeamByName,
+  updateTeam,
+  updateTeamModel,
+} from '$lib/server/entities/team'
 import { getUserWithUserTeamsById, isUserAdmin, isUserInTeam } from '$lib/server/entities/user'
 import { getUserTeamById, removeUserTeam, updateUserTeamRole } from '$lib/server/entities/userTeams'
 import { decrypt } from '$lib/server/utils/crypto'
@@ -52,6 +57,7 @@ export const load: PageServerLoad = async ({ params, locals: { currentUser } }) 
 export const actions: Actions = {
   updateTeamDetails: async ({ request, params, locals }) => {
     const fields = Object.fromEntries(await request.formData())
+    console.log(fields)
     const teamId = Number(params.id)
     try {
       const schema = z
@@ -249,6 +255,28 @@ export const actions: Actions = {
     return {
       invitationSection: {
         success: `Invitation with id ${invitationId} successfully deleted.`,
+      },
+    }
+  },
+  updateTeamModel: async ({ request, params, locals }) => {
+    const teamId = Number(params.id)
+    const fields = Object.fromEntries(await request.formData())
+    const model = fields.model.toString()
+
+    const requestingUserId = locals.currentUser.id
+    if (!(await isUserAdmin(teamId, requestingUserId))) {
+      return fail(401, {
+        modelSection: {
+          error: 'You are no admin of this team.',
+        },
+      })
+    }
+
+    await updateTeamModel(teamId, model)
+
+    return {
+      modelSection: {
+        success: 'Model updated successfully.',
       },
     }
   },

--- a/src/routes/app/settings/teams/[id]/+page.server.ts
+++ b/src/routes/app/settings/teams/[id]/+page.server.ts
@@ -14,6 +14,7 @@ import { error, fail } from '@sveltejs/kit'
 import { randomUUID } from 'crypto'
 import { z, ZodError } from 'zod'
 import type { Actions, PageServerLoad } from './$types'
+import { getAvailableModels } from '$lib/server/api/openai'
 
 export const load: PageServerLoad = async ({ params, locals: { currentUser } }) => {
   const user = await getUserWithUserTeamsById(currentUser.id)
@@ -25,6 +26,7 @@ export const load: PageServerLoad = async ({ params, locals: { currentUser } }) 
   if (!userTeam) throw error(404, "Doesn't belong to this team or the team doesn't exist")
 
   const team = await getTeamByIdWithMembers(teamId)
+  const availableModels = await getAvailableModels(team)
 
   if (team?.openAiApiKey) {
     if (userTeam?.role === Role.MEMBER) {
@@ -43,6 +45,7 @@ export const load: PageServerLoad = async ({ params, locals: { currentUser } }) 
     team,
     chatCount: countTeamChats(userTeam.teamId),
     invitations,
+    availableModels,
   }
 }
 

--- a/src/routes/app/settings/teams/[id]/+page.server.ts
+++ b/src/routes/app/settings/teams/[id]/+page.server.ts
@@ -135,7 +135,7 @@ export const actions: Actions = {
     if (!(await isUserAdmin(teamId, requestingUserId))) {
       return fail(401, {
         userSection: {
-          error: 'You are no admin of this team.',
+          error: 'You are not admin of this team.',
         },
       })
     }
@@ -206,7 +206,7 @@ export const actions: Actions = {
     if (!(await isUserAdmin(teamId, requestingUserId))) {
       return fail(401, {
         invitationSection: {
-          error: 'You are no admin of this team.',
+          error: 'You are not admin of this team.',
         },
       })
     }
@@ -227,7 +227,7 @@ export const actions: Actions = {
     if (!(await isUserAdmin(teamId, requestingUserId))) {
       return fail(401, {
         userSection: {
-          error: 'You are no admin of this team.',
+          error: 'You are not admin of this team.',
         },
       })
     }
@@ -267,7 +267,7 @@ export const actions: Actions = {
     if (!(await isUserAdmin(teamId, requestingUserId))) {
       return fail(401, {
         modelSection: {
-          error: 'You are no admin of this team.',
+          error: 'You are not admin of this team.',
         },
       })
     }

--- a/src/routes/app/settings/teams/[id]/+page.svelte
+++ b/src/routes/app/settings/teams/[id]/+page.svelte
@@ -5,6 +5,8 @@
   import TeamKeys from '$lib/components/TeamKeys.svelte'
   import TeamInvitationList from '$lib/components/TeamInvitationList.svelte'
 
+  import TeamDefaultModel from '$lib/components/TeamDefaultModel.svelte'
+
   export let data: PageData
   export let form: ActionData
 
@@ -22,4 +24,5 @@
   <TeamKeys userTeam={data.userTeam} team={data.team} form={form?.keySection} />
   <TeamInvitationList invitations={data.invitations} {isAdmin} form={form?.invitationSection} />
   <TeamMemberList team={data.team} userTeam={data.userTeam} form={form?.userSection} />
+  <TeamDefaultModel models={data.availableModels} />
 </div>

--- a/src/routes/app/settings/teams/[id]/+page.svelte
+++ b/src/routes/app/settings/teams/[id]/+page.svelte
@@ -9,7 +9,7 @@
 
   export let data: PageData
   export let form: ActionData
-
+  let model = data.team.teamModel
   $: isAdmin = data.userTeam.role !== 'MEMBER'
 </script>
 
@@ -24,5 +24,5 @@
   <TeamKeys userTeam={data.userTeam} team={data.team} form={form?.keySection} />
   <TeamInvitationList invitations={data.invitations} {isAdmin} form={form?.invitationSection} />
   <TeamMemberList team={data.team} userTeam={data.userTeam} form={form?.userSection} />
-  <TeamDefaultModel models={data.availableModels} />
+  <TeamDefaultModel bind:model models={data.availableModels} />
 </div>

--- a/src/routes/app/settings/teams/[id]/+page.svelte
+++ b/src/routes/app/settings/teams/[id]/+page.svelte
@@ -24,5 +24,7 @@
   <TeamKeys userTeam={data.userTeam} team={data.team} form={form?.keySection} />
   <TeamInvitationList invitations={data.invitations} {isAdmin} form={form?.invitationSection} />
   <TeamMemberList team={data.team} userTeam={data.userTeam} form={form?.userSection} />
-  <TeamDefaultModel bind:model models={data.availableModels} />
+  {#if isAdmin}
+    <TeamDefaultModel bind:model models={data.availableModels} form={form?.modelSection} />
+  {/if}
 </div>


### PR DESCRIPTION
This PR:
- adds support for the model gpt-4o. 
- adds the functionality for the team admin to choose a default model under team settings. The chat defaults to use this model whenever a member of the team creates a new chat. If the team admin doesn't choose a model, it is defaulted to 3.5-turbo. 


Let me know what you think and if there are any improvements I could make :) 

Closes https://github.com/prototypsthlm/taco/issues/175
