### PR TITLE
Malibu-29: Make sign up and sign in the same style

### DIFF
--- a/src/routes/signin/+page.svelte
+++ b/src/routes/signin/+page.svelte
@@ -17,21 +17,19 @@
   ></script>
 </svelte:head>
 
-<div
-  class="min-h-screen bg-gray-50 dark:bg-gray-800 flex flex-col justify-center py-12 sm:px-6 lg:px-8"
->
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md flex flex-col items-center gap-4">
     <div class="text-3xl md:text-5xl">
       <TacoIcon class="h-16 md:h-24" />
     </div>
     <h2
-      class="mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100"
+      class="mt-6 text-center text-3xl font-bold leading-9 tracking-tight text-gray-900 dark:text-gray-100"
     >
       Sign in to your account
     </h2>
   </div>
 
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
+  <div class="sm:mx-auto sm:w-full sm:max-w-[480px]">
     <div class="bg-white dark:bg-gray-900 px-6 py-12 shadow sm:px-12">
       <Alert
         type={(form?.error && 'error') || (form?.success && 'success')}
@@ -88,7 +86,7 @@
           <div class="text-sm leading-6">
             <a
               href="/forgot-password"
-              class="font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-500"
+              class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
               >Forgot password?</a
             >
           </div>
@@ -97,7 +95,7 @@
         <div>
           <button
             type="submit"
-            class="flex w-full justify-center rounded-md bg-indigo-600 dark:bg-indigo-400 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+            class="flex w-full justify-center rounded-md bg-indigo-600 dark:bg-indigo-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 dark:hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
             >Sign in
           </button>
         </div>
@@ -106,9 +104,7 @@
 
     <p class="mt-10 text-center text-sm text-gray-500">
       Not a member?
-      <a
-        href="/signup"
-        class="font-semibold leading-6 text-indigo-600 dark:text-indigo-400 hover:text-indigo-500"
+      <a href="/signup" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
         >Sign up</a
       >
     </p>

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -17,9 +17,7 @@
   ></script>
 </svelte:head>
 
-<div
-  class="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center py-12 sm:px-6 lg:px-8"
->
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md flex flex-col items-center gap-4">
     <div class="text-3xl md:text-5xl">
       <TacoIcon class="h-16 md:h-24" />
@@ -31,7 +29,7 @@
     </h2>
   </div>
 
-  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
+  <div class="sm:mx-auto sm:w-full sm:max-w-[480px]">
     <div class="bg-white dark:bg-gray-900 px-6 py-12 shadow sm:rounded-lg sm:px-12">
       <Alert
         type={(form?.error && 'error') || (form?.success && 'success')}


### PR DESCRIPTION
- Removes the box around the inputs on sign in page.
- Sign in buttons are the same colours
- Page title is the same size